### PR TITLE
Add workflow to publish Doxygen docs to GitHub Pages

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,41 @@
+name: Build and Deploy Docs
+
+on:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: "pages"
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Install Doxygen
+        run: sudo apt-get update && sudo apt-get install -y doxygen graphviz
+      - name: Build documentation
+        working-directory: documentation
+        run: doxygen Doxyfile
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v2
+        with:
+          path: documentation/build/html
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v2


### PR DESCRIPTION
## Summary
- ensure Doxygen runs from the documentation directory so sources are found
- install graphviz alongside Doxygen and publish generated HTML to GitHub Pages

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689646cb4548832a8de0de8b236a013e