### PR TITLE
Add workflow to publish Doxygen docs to GitHub Pages

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,45 @@
+name: Build and Deploy Docs
+
+on:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: "pages"
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Setup Pages
+        uses: actions/configure-pages@v5
+      - name: Install Doxygen
+        run: sudo apt-get update && sudo apt-get install -y doxygen graphviz
+      - name: Build documentation
+        run: |
+          cd documentation
+          doxygen Doxyfile
+          touch build/html/.nojekyll
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: documentation/build/html
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
## Summary
- ensure Doxygen runs from the documentation directory so sources are found
- install graphviz alongside Doxygen and publish generated HTML to GitHub Pages
- switch Pages workflow to latest artifact and deploy actions
- configure Pages and disable Jekyll so the deployed site serves the generated Doxygen output
- run Doxygen inside docs directory and create `.nojekyll` within the built output so Python file pages deploy correctly

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689646cb4548832a8de0de8b236a013e