### PR TITLE
docs: add Doxygen headers to demos

### DIFF
--- a/demos/qpsk_ber_snr_sweep.py
+++ b/demos/qpsk_ber_snr_sweep.py
@@ -1,12 +1,9 @@
-"""QPSK BER versus SNR sweep demo.
-
-Generate a single-polarization QPSK signal at 64 GBd, sweep the SNR from
-0 to 17 dB in 1 dB steps, add complex AWGN, demodulate, calculate the bit
-error rate (BER), plot BER versus SNR, and overlay the theoretical curve.
-
-Run this file directly with Python to display and save the plot:
-
-    python demos/qpsk_ber_snr_sweep.py
+"""@file qpsk_ber_snr_sweep.py
+@brief Sweep SNR and plot BER for a QPSK signal.
+@details Generates a single-polarization 64 GBd QPSK signal, adds complex AWGN
+across 0–17 dB in 1 dB steps, demodulates, computes the bit error rate,
+and overlays the theoretical BER curve on the plot.
+Run with `python demos/qpsk_ber_snr_sweep.py`.
 """
 
 import os

--- a/demos/qpsk_constellation.py
+++ b/demos/qpsk_constellation.py
@@ -1,11 +1,8 @@
-"""QPSK signal generation demo.
-
-Generate a single-polarization QPSK signal at 64 GBd with 2**18 samples
-using the QAMpy submodule and plot the resulting constellation.
-
-Run this file directly with Python to display the plot:
-
-    python demos/qpsk_constellation.py
+"""@file qpsk_constellation.py
+@brief Generate and plot a QPSK constellation.
+@details Creates a single-polarization QPSK signal at 64 GBd with 2**18 samples
+using QAMpy and displays its constellation diagram.
+Run with `python demos/qpsk_constellation.py`.
 """
 
 import os

--- a/demos/qpsk_constellation_awgn.py
+++ b/demos/qpsk_constellation_awgn.py
@@ -1,12 +1,9 @@
-"""QPSK signal with AWGN noise demo.
-
-Generate a single-polarization QPSK signal at 64 GBd with 2**18 samples,
-add complex AWGN at a specified SNR using QAMpy's ``change_snr``
-function, and plot the constellations before and after noise injection.
-
-Run this file directly with Python to display the plots:
-
-    python demos/qpsk_constellation_awgn.py
+"""@file qpsk_constellation_awgn.py
+@brief Add AWGN to a QPSK signal and plot constellations.
+@details Generates a single-polarization QPSK signal at 64 GBd with 2**18 samples,
+applies complex AWGN at a specified SNR using QAMpy's ``change_snr`` function,
+and plots constellations before and after noise injection.
+Run with `python demos/qpsk_constellation_awgn.py`.
 """
 
 import os

--- a/demos/qpsk_rrc_upsample_eye.py
+++ b/demos/qpsk_rrc_upsample_eye.py
@@ -1,16 +1,10 @@
-"""QPSK RRC filtering and eye-diagram demo.
-
-Generate a single-polarization QPSK signal and upsample it using a
-root-raised cosine (RRC) filter to a user defined oversampling ratio.
-The constellation of the original symbols is displayed and, in a
-separate figure, the eye diagram of the RRC filtered signal.
-
-Run this file directly with Python to display the plots:
-
-    python demos/qpsk_rrc_upsample_eye.py
-
-Use ``main(osr, roll_off)`` to customize the oversampling ratio and
-RRC roll-off.
+"""@file qpsk_rrc_upsample_eye.py
+@brief Upsample a QPSK signal with an RRC filter and plot the eye diagram.
+@details Generates a single-polarization QPSK signal, upsamples it with an
+RRC filter to a user-defined oversampling ratio, plots the original
+constellation, and shows the eye diagram of the filtered signal.
+Run with `python demos/qpsk_rrc_upsample_eye.py`.
+Use ``main(osr, roll_off)`` to customize oversampling and roll-off.
 """
 
 from __future__ import annotations


### PR DESCRIPTION
## Summary
- document QPSK constellation demo with Doxygen header
- describe AWGN noise demo and RRC eye-diagram demo for Doxygen
- annotate BER vs SNR sweep demo with Doxygen metadata

## Testing
- `python -m pytest tests`

------
https://chatgpt.com/codex/tasks/task_e_689656186620832a8e6c4f70be7b35bc