### PR TITLE
Add QPSK AWGN integration test

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,7 @@ role definitions in [AGENTS.md](AGENTS.md). Key points:
 ├─ documentation/
 │  ├─ Doxyfile
 │  └─ README.md
+├─ helpers/
 ├─ requirements.txt
 └─ tests/
 ```
@@ -105,6 +106,7 @@ role definitions in [AGENTS.md](AGENTS.md). Key points:
 - `constraints.txt` – pinned versions for dependencies.
 - `demos/` – example scripts and notebooks.
 - `documentation/` – project documentation.
+- `helpers/` – utility functions shared across the project.
 - `requirements.txt` – project dependencies.
 - `tests/` – test suite.
 

--- a/helpers/__init__.py
+++ b/helpers/__init__.py
@@ -1,0 +1,1 @@
+"""Helper utilities for tests and demos."""

--- a/helpers/osnr.py
+++ b/helpers/osnr.py
@@ -1,0 +1,31 @@
+"""OSNR and SNR conversion utilities."""
+
+from __future__ import annotations
+
+import numpy as np
+
+REFERENCE_BW_HZ = 12.5e9  # 0.1 nm reference bandwidth
+
+
+def osnr_to_snr(osnr_db: float, symbol_rate: float, npol: int) -> float:
+    """Convert OSNR (dB/0.1 nm) to per-polarization SNR in dB.
+
+    Parameters
+    ----------
+    osnr_db : float
+        Optical signal-to-noise ratio in decibels.
+    symbol_rate : float
+        Symbol rate of the transmitted signal.
+    npol : int
+        Number of polarizations in the signal.
+
+    Returns
+    -------
+    float
+        Per-polarization signal-to-noise ratio in decibels.
+    """
+    return (
+        osnr_db
+        - 10 * np.log10(symbol_rate / REFERENCE_BW_HZ)
+        - 10 * np.log10(npol)
+    )

--- a/tests/integration_config.py
+++ b/tests/integration_config.py
@@ -1,0 +1,27 @@
+"""Configuration for integration tests.
+
+This module defines dataclasses that store commonly used
+parameters for integration testing. Users can modify these
+values to explore different link configurations without
+changing the tests themselves.
+"""
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class QPSKAWGNConfig:
+    """Parameters for the QPSK over AWGN integration test.
+
+    The noise level is specified as an optical signal-to-noise ratio (OSNR) in
+    decibels using a 0.1 nm reference bandwidth (12.5 GHz).
+    """
+
+    modulation_order: int = 4
+    symbol_rate: float = 64e9  # 64 GBd
+    roll_off: float = 0.1
+    oversampling_ratio: int = 2
+    osnr_db: float = 30.0
+    n_symbols: int = 2048
+    npol: int = 2  # dual-polarization
+    seed: int | None = 0

--- a/tests/test_integration_qpsk_awgn.py
+++ b/tests/test_integration_qpsk_awgn.py
@@ -1,0 +1,51 @@
+"""End-to-end dual-polarization QPSK link over an optical AWGN channel.
+
+This test verifies a dual-polarization QPSK transmission using root-raised
+cosine pulse shaping with a roll-off of 0.1 and an oversampling ratio of two
+samples per symbol. The optical channel is modeled as additive white Gaussian
+noise (AWGN) with a specified OSNR. The receiver employs only a matched RRC
+filter without further equalization.
+"""
+
+import sys
+from pathlib import Path
+
+import numpy as np
+
+# Add QAMpy submodule to path
+BASE_DIR = Path(__file__).resolve().parents[1]
+QAMPY_PATH = BASE_DIR / "base" / "QAMpy"
+if str(QAMPY_PATH) not in sys.path:
+    sys.path.insert(0, str(QAMPY_PATH))
+
+from qampy.signals import SignalQAMGrayCoded
+from qampy import impairments
+
+from integration_config import QPSKAWGNConfig
+from helpers.osnr import osnr_to_snr
+
+
+def test_qpsk_awgn_link_ber_below_threshold() -> None:
+    """Generate, transmit and recover a QPSK signal over AWGN."""
+    cfg = QPSKAWGNConfig()
+
+    tx = SignalQAMGrayCoded(
+        M=cfg.modulation_order,
+        N=cfg.n_symbols,
+        nmodes=cfg.npol,  # dual polarization
+        fb=cfg.symbol_rate,
+        seed=cfg.seed,
+    )
+
+    tx_os = tx.resample(
+        cfg.symbol_rate * cfg.oversampling_ratio, beta=cfg.roll_off
+    )
+
+    snr_db = osnr_to_snr(cfg.osnr_db, cfg.symbol_rate, cfg.npol)
+    rx_os = impairments.change_snr(tx_os, snr_db)
+
+    rx = rx_os.resample(cfg.symbol_rate, beta=cfg.roll_off)
+
+    ber = tx.cal_ber(signal_rx=rx)
+
+    assert np.all(ber < 1e-3)


### PR DESCRIPTION
## Summary
- move OSNR-to-SNR converter into shared `helpers` module
- rename polarization field to `npol` and simplify AWGN integration test
- document new `helpers` directory

## Testing
- `python -m pytest tests -q`


------
https://chatgpt.com/codex/tasks/task_e_68965cfab438832a9931d9717a3a6dfe