### PR TITLE
chore: silence qampy warnings in tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,7 @@ role definitions in [AGENTS.md](AGENTS.md). Key points:
 │  ├─ Doxyfile
 │  └─ README.md
 ├─ helpers/
+├─ pytest.ini
 ├─ requirements.txt
 └─ tests/
 ```
@@ -109,6 +110,7 @@ role definitions in [AGENTS.md](AGENTS.md). Key points:
 - `demos/` – example scripts and notebooks.
 - `documentation/` – project documentation.
 - `helpers/` – utility functions shared across the project.
+- `pytest.ini` – Pytest configuration suppressing QAMpy deprecation warnings.
 - `requirements.txt` – project dependencies.
 - `tests/` – test suite.
 

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,5 @@
+[pytest]
+filterwarnings =
+    ignore:invalid escape sequence:DeprecationWarning:qampy\.theory
+    ignore:invalid escape sequence:DeprecationWarning:qampy\.core\.impairments
+    ignore:The binary mode of fromstring is deprecated:DeprecationWarning:qampy\.signals


### PR DESCRIPTION
## Summary
- add `pytest.ini` to filter deprecation warnings from bundled QAMpy
- document new pytest configuration in README

## Testing
- `PYTHONPATH=. pytest tests`


------
https://chatgpt.com/codex/tasks/task_e_6896645db3e8832a9ec2cd9a3ec659b2