### PR TITLE
Clarify pytest warning requirement

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -21,4 +21,4 @@ jobs:
       - name: Install dependencies
         run: pip install -r requirements.txt -c constraints.txt
       - name: Run tests
-        run: python -m pytest tests
+        run: PYTHONPATH=base/QAMpy python -W error -m pytest tests

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -64,6 +64,7 @@ References to QAMpy refer to the submodule located at `/base/QAMpy`; do not atte
 - Unit tests check individual DSP blocks.
 - Integration tests validate complete TX → Channel → RX pipelines.
 - Simulation Agent includes visual inspection artifacts (plots) in PRs.
+- Run tests with `pytest`, treating warnings as errors; the suite must pass without warnings.
 
 ### Release
 - Release Agent bumps version, updates changelog, and publishes release.
@@ -77,7 +78,7 @@ References to QAMpy refer to the submodule located at `/base/QAMpy`; do not atte
 - Always use QAMpy functions if available.
 - Avoid glue code; it is never recommended.
 - Follow "Divide and conquer"—each function should implement a single, well-defined functionality with optional configuration.
-- Tests must pass before merge.
+- Tests must pass without warnings before merge.
 - Avoid adding new dependencies unless absolutely necessary; prefer using the existing requirements.
 
 ## Artifacts & Storage

--- a/README.md
+++ b/README.md
@@ -50,10 +50,10 @@ python demos/qpsk_rrc_upsample_eye.py
 python demos/qpsk_ber_snr_sweep.py
 ```
 
-Run tests with `pytest`:
+Run tests with `pytest`, treating warnings as errors:
 
 ```bash
-python -m pytest tests
+python -W error -m pytest tests
 ```
 
 ## Documentation
@@ -84,7 +84,7 @@ role definitions in [AGENTS.md](AGENTS.md). Key points:
 
 - Adhere to PEP-8 and include standard Python docstrings for new modules.
 - Update or add tests for any new functionality.
-- Ensure all tests pass before submitting a PR.
+- Ensure all tests pass without warnings before submitting a PR.
 - Avoid adding new dependencies unless absolutely necessary and discuss them in the PR.
 
 ## Directory Structure


### PR DESCRIPTION
## Summary
- Document that tests must pass without warnings
- Enforce warning-free `pytest` runs in CI

## Testing
- `PYTHONPATH=base/QAMpy python -W error -m pytest tests` *(fails: SyntaxError: invalid escape sequence '\\l')*

------
https://chatgpt.com/codex/tasks/task_e_68966a29d71c832a9f12313163e8c834