### PR TITLE
fix: correct pages deployment workflow

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -38,8 +38,9 @@ jobs:
     runs-on: ubuntu-latest
     environment:
       name: github-pages
-      url: ${{ steps.deployment.outputs.page_url }}
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
         uses: actions/deploy-pages@v4
+      - name: Display Page URL
+        run: echo "Page URL: ${{ steps.deployment.outputs.page_url }}"


### PR DESCRIPTION
## Summary
- fix broken GitHub Pages workflow by removing invalid environment URL reference
- echo deployed Page URL after deployment for visibility

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'qampy')*

------
https://chatgpt.com/codex/tasks/task_e_68966f46da58832a9c8a74b1f1f4d0be