### PR TITLE
Automatically initialize Git submodules

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,9 @@
+[submodule]
+        recurse = true
+        fetchRecurseSubmodules = true
+
 [submodule "base/QAMpy"]
-	path = base/QAMpy
-	url = https://github.com/ChalmersPhotonicsLab/QAMpy
+        path = base/QAMpy
+        url = https://github.com/ChalmersPhotonicsLab/QAMpy
+        branch = master
+        update = checkout

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+-e ./base/QAMpy
 numpy==1.23.5
 scipy==1.9.3
 matplotlib==3.10.5


### PR DESCRIPTION
## Summary
- Configure Git to recurse into submodules and track `QAMpy` on its `master` branch
- Install `QAMpy` from the included submodule by default

## Testing
- `pip install -r requirements.txt` *(fails: building editable for qampy, exit code 1)*
- `pytest` *(fails: ModuleNotFoundError: No module named 'qampy')*
