### PR TITLE
Restore QAMpy submodule and configure tests

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -49,6 +49,7 @@ This document defines the roles, responsibilities, and workflows for human and A
 - `/documentation` – Project documentation.
 
 References to QAMpy refer to the submodule located at `/base/QAMpy`; do not attempt to install QAMpy as a standalone dependency.
+Never replace or vendor the QAMpy code; keep it as a Git submodule and update it via standard submodule workflows.
 
 ## Workflows
 

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,3 +1,4 @@
 [pytest]
+testpaths = tests
 filterwarnings =
     ignore::DeprecationWarning:.*qampy

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
--e ./base/QAMpy
 numpy==1.23.5
 scipy==1.9.3
 matplotlib==3.10.5

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,20 @@
+"""Pytest configuration for test suite.
+
+Adds the QAMpy submodule to ``sys.path`` so that tests can import it
+without installing the package.
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+# Compute repository root and ensure it's on ``sys.path`` so internal helpers
+# and packages can be imported during tests.
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+# Add the QAMpy submodule to the path without installing it
+QAMPY_PATH = ROOT / "base" / "QAMpy"
+if str(QAMPY_PATH) not in sys.path:
+    sys.path.insert(0, str(QAMPY_PATH))


### PR DESCRIPTION
## Summary
- document in `AGENTS.md` that QAMpy must remain a git submodule and must not be vendored
- remove editable QAMpy requirement and configure pytest to discover only local tests
- add test configuration that exposes the QAMpy submodule on `sys.path`

## Testing
- `pip install -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6897b007f528832aac0636b6a4dd5e7f