### PR TITLE
docs: mention Windows venv activation

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,10 @@ One of the goals of this project is to test code development workflows using age
 git clone --recurse-submodules <repo_url>
 cd qpsk-transceiver
 python -m venv .venv
+# Activate the virtual environment (Unix/macOS)
 source .venv/bin/activate
+# Activate the virtual environment (Windows)
+.\.venv\Scripts\activate
 pip install -r requirements.txt -c constraints.txt
 ```
 


### PR DESCRIPTION
## Summary
- document how to activate the virtual environment on Windows

## Testing
- `python -W error -m pytest tests` *(fails: ModuleNotFoundError: No module named 'qampy')*


------
https://chatgpt.com/codex/tasks/task_e_6897ba99cefc832a96c83d024dbe98c1