### PR TITLE
docs: expand osnr_to_snr docstring

### DIFF
--- a/helpers/osnr.py
+++ b/helpers/osnr.py
@@ -15,14 +15,20 @@ def osnr_to_snr(osnr_db: float, symbol_rate: float, npol: int) -> float:
     osnr_db : float
         Optical signal-to-noise ratio in decibels.
     symbol_rate : float
-        Symbol rate of the transmitted signal.
+        Symbol rate of the transmitted signal in Hz.
     npol : int
-        Number of polarizations in the signal.
+        Number of signal polarizations (1 for single polarization,
+        2 for dual).
 
     Returns
     -------
     float
         Per-polarization signal-to-noise ratio in decibels.
+
+    Examples
+    --------
+    >>> osnr_to_snr(osnr_db=20, symbol_rate=32e9, npol=2)
+    12.9...
     """
     return (
         osnr_db


### PR DESCRIPTION
## Summary
- document units for `symbol_rate` and `npol`
- add usage example for OSNR-to-SNR conversion

## Testing
- `PYTHONPATH=base/QAMpy pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6897bac2bd50832aa99386b982804945