### PR TITLE
Add docstrings to eye diagram tests

### DIFF
--- a/tests/test_plot_eye_diagram.py
+++ b/tests/test_plot_eye_diagram.py
@@ -1,3 +1,5 @@
+"""Tests for the ``plot_eye_diagram`` helper used in QPSK visualization."""
+
 import sys
 from pathlib import Path
 
@@ -13,10 +15,13 @@ from demos.qpsk_rrc_upsample_eye import plot_eye_diagram
 
 
 def _create_signal(length: int) -> np.ndarray:
+    """Return a simple complex ramp signal of the requested length."""
+
     return np.linspace(0, 1, length) + 1j * 0
 
 
 def test_plot_eye_diagram_draws_expected_traces():
+    """``plot_eye_diagram`` draws one trace per symbol except the first."""
     sps = 2
     signal = _create_signal(8)
     fig, ax = plt.subplots()
@@ -27,6 +32,7 @@ def test_plot_eye_diagram_draws_expected_traces():
 
 
 def test_plot_eye_diagram_sets_labels_and_title():
+    """``plot_eye_diagram`` sets title and axis labels appropriately."""
     sps = 2
     signal = _create_signal(8)
     fig, ax = plt.subplots()
@@ -38,6 +44,7 @@ def test_plot_eye_diagram_sets_labels_and_title():
 
 
 def test_plot_eye_diagram_plots_only_real_part():
+    """Only the real part of the signal is plotted."""
     sps = 2
     real = np.arange(8)
     imag = np.linspace(1, -1, 8)
@@ -51,6 +58,7 @@ def test_plot_eye_diagram_plots_only_real_part():
 
 
 def test_plot_eye_diagram_enables_grid():
+    """Gridlines are enabled on both axes."""
     sps = 2
     signal = _create_signal(8)
     fig, ax = plt.subplots()
@@ -61,6 +69,7 @@ def test_plot_eye_diagram_enables_grid():
 
 
 def test_plot_eye_diagram_with_short_signal_draws_no_lines():
+    """Signals shorter than two spans produce no plotted lines."""
     sps = 4
     signal = _create_signal(6)
     fig, ax = plt.subplots()
@@ -70,6 +79,7 @@ def test_plot_eye_diagram_with_short_signal_draws_no_lines():
 
 
 def test_plot_eye_diagram_segments_are_sequential():
+    """Consecutive segments appear in sequential order."""
     sps = 2
     signal = _create_signal(12)
     fig, ax = plt.subplots()


### PR DESCRIPTION
## Summary
- document module and helper in `test_plot_eye_diagram.py`
- add docstrings describing each test scenario

## Testing
- `pytest tests/test_plot_eye_diagram.py`

------
https://chatgpt.com/codex/tasks/task_e_6897c0409e9c832aaec389f3f41f55b0