### PR TITLE
docs: clarify validate_osr tests

### DIFF
--- a/tests/test_validate_osr.py
+++ b/tests/test_validate_osr.py
@@ -1,3 +1,9 @@
+"""Tests for input validation in :func:`validate_osr`.
+
+These tests ensure that ``validate_osr`` accepts only positive integer
+oversampling ratios and rejects invalid inputs.
+"""
+
 import pytest
 import sys
 from pathlib import Path
@@ -9,36 +15,50 @@ from demos.qpsk_rrc_upsample_eye import validate_osr
 
 
 def test_validate_osr_accepts_positive_integer():
+    """Returns the OSR when given a positive integer."""
+
     assert validate_osr(4) == 4
 
 
 def test_validate_osr_rejects_non_integer():
+    """Non-integer OSR values raise ``ValueError``."""
+
     with pytest.raises(ValueError):
         validate_osr(2.5)
 
 
 def test_validate_osr_rejects_non_positive():
+    """Zero or negative OSR values raise ``ValueError``."""
+
     for invalid in [0, -3]:
         with pytest.raises(ValueError):
             validate_osr(invalid)
 
 
 def test_validate_osr_rejects_nan():
+    """``NaN`` OSR values raise ``ValueError``."""
+
     with pytest.raises(ValueError):
         validate_osr(np.nan)
 
 
 def test_validate_osr_rejects_infinity():
+    """Infinite OSR values raise ``ValueError``."""
+
     with pytest.raises(ValueError):
         validate_osr(np.inf)
 
  
 def test_validate_osr_rejects_bool():
+    """Boolean inputs raise ``TypeError``."""
+
     with pytest.raises(TypeError):
         validate_osr(True)
 
 
 def test_validate_osr_rejects_non_numeric():
+    """Non-numeric inputs raise ``TypeError``."""
+
     with pytest.raises(TypeError):
         validate_osr("3")
 


### PR DESCRIPTION
## Summary
- add module docstring explaining validate_osr input validation tests
- document expectations for each validate_osr test case

## Testing
- `pytest -W error` *(fails: SyntaxError: invalid escape sequence '\\l' in QAMpy)*
- `pytest tests/test_validate_osr.py -W error`


------
https://chatgpt.com/codex/tasks/task_e_6897c046e0e8832a913d514b641a6414