### PR TITLE
docs: add diagram conversion instructions

### DIFF
--- a/documentation/README.md
+++ b/documentation/README.md
@@ -5,6 +5,16 @@ This directory contains configuration for building API documentation using
 directly, so modules and functions should include docstrings. Diagrams used
 throughout the documentation live under `diagrams/`.
 
+### Diagram conversion
+
+Use [Graphviz](https://graphviz.org/) to convert `.dot` files in `diagrams/` to `.svg` images:
+
+```bash
+dot -Tsvg qpsk_transmission_chain.dot -o qpsk_transmission_chain.svg
+```
+
+Regenerate diagrams whenever the underlying `.dot` files change or the signal chain is updated.
+
 ## Generating the docs
 
 1. Install Doxygen and Graphviz.


### PR DESCRIPTION
## Summary
- document converting Graphviz `.dot` diagrams to SVG and when to regenerate them

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6897c038f424832a9e4990440e664f99