### PR TITLE
Document OSNR reference bandwidth constant

### DIFF
--- a/helpers/osnr.py
+++ b/helpers/osnr.py
@@ -1,10 +1,16 @@
-"""OSNR and SNR conversion utilities."""
+"""OSNR and SNR conversion utilities.
+
+Attributes
+----------
+REFERENCE_BW_HZ : float
+    0.1 nm reference bandwidth in Hz.
+"""
 
 from __future__ import annotations
 
 import numpy as np
 
-REFERENCE_BW_HZ = 12.5e9  # 0.1 nm reference bandwidth
+REFERENCE_BW_HZ = 12.5e9
 
 
 def osnr_to_snr(osnr_db: float, symbol_rate: float, npol: int) -> float:


### PR DESCRIPTION
## Summary
- document `REFERENCE_BW_HZ` constant in `helpers.osnr` module docstring with an Attributes section

## Testing
- `PYTHONPATH=base/QAMpy pytest`

------
https://chatgpt.com/codex/tasks/task_e_6897c052cb00832a88cb126366f13f74