### PR TITLE
Add project brief and logo to Doxygen docs

### DIFF
--- a/documentation/Doxyfile
+++ b/documentation/Doxyfile
@@ -2,6 +2,8 @@
 # Documentation generation configuration
 
 PROJECT_NAME = "qpsk-transceiver"
+PROJECT_BRIEF = "QPSK transceiver simulation"
+PROJECT_LOGO = ../documentation/diagrams/logo.svg
 OUTPUT_DIRECTORY = build
 GENERATE_HTML = YES
 GENERATE_LATEX = NO

--- a/documentation/diagrams/logo.svg
+++ b/documentation/diagrams/logo.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="120" height="120">
+  <rect width="120" height="120" fill="#1f77b4"/>
+  <text x="60" y="65" font-size="40" text-anchor="middle" fill="#ffffff">QPSK</text>
+</svg>


### PR DESCRIPTION
## Summary
- Add `PROJECT_BRIEF` to Doxygen config to summarize the QPSK transceiver simulation
- Set `PROJECT_LOGO` and include a simple SVG logo
- Regenerate Doxygen docs to display the new brief and logo

## Testing
- `doxygen Doxyfile`
- `python -W error -m pytest tests`


------
https://chatgpt.com/codex/tasks/task_e_6897c3d8998c832ab6caa56d6829134e