### PR TITLE
docs: fix image links

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ infrastructure that showcase how to construct a complete QPSK transmission
 chain.
 
 
-\image html qpsk_transmission_chain.svg "QPSK transmission chain"
+![QPSK transmission chain](documentation/diagrams/qpsk_transmission_chain.svg)
 
 The transceiver passes through the following stages:
 

--- a/demos/README.md
+++ b/demos/README.md
@@ -1,5 +1,5 @@
 # Demos
 
-\image html qpsk_transmission_chain.svg "QPSK transmission chain"
+![QPSK transmission chain](../documentation/diagrams/qpsk_transmission_chain.svg)
 
 This directory contains example scripts demonstrating various stages of the QPSK transceiver.

--- a/documentation/README.md
+++ b/documentation/README.md
@@ -5,7 +5,7 @@ This directory contains configuration for building API documentation using
 directly, so modules and functions should include docstrings. Diagrams used
 throughout the documentation live under `diagrams/`.
 
-\image html qpsk_transmission_chain.svg "QPSK transmission chain"
+![QPSK transmission chain](diagrams/qpsk_transmission_chain.svg)
 
 ### Diagram conversion
 


### PR DESCRIPTION
## Summary
- Display transmission chain diagram using standard Markdown in README and docs
- Update demos README to link to shared diagram

## Testing
- `python -W error -m pytest tests`

------
https://chatgpt.com/codex/tasks/task_e_6897c919c994832a990e9391b0f1d764